### PR TITLE
Add setting to exclude specific paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ A simple access auditing middleware intended for use with Slim Framework applica
            'writeOnce' => false,
            'custom' => [],
            'captureResponse' => false,
+           'ignoredPaths' => [
+               '/exclude-all-paths/under-this-root',
+           ],
        ];
        return new \jstnryan\AccessLog\AccessLog($c->audit_database, $settings);
    };


### PR DESCRIPTION
Adds an `ignoredPaths` option to the settings array, which accepts an array of strings representing endpoint path roots for which the logging functionality should be disabled.