### PR TITLE
Make accessLog response columns allow a default value

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -26,10 +26,10 @@ CREATE TABLE `accessLog` (
     `requestTime` DATETIME NOT NULL,
     `requestUri` VARCHAR(255) NOT NULL,
     `requestMethod` INT(1) UNSIGNED NOT NULL,
-    `requestParams` TEXT,
+    `requestParams` TEXT DEFAULT NULL,
     `responseTime` DATETIME DEFAULT NULL,
-    `responseStatus` INT(3) UNSIGNED NOT NULL,
-    `response` TEXT,
+    `responseStatus` INT(3) UNSIGNED DEFAULT NULL,
+    `response` TEXT DEFAULT NULL,
     PRIMARY KEY (`accessLogID`),
     FOREIGN KEY (`requestMethod`) REFERENCES `requestMethod`(`requestMethodID`)
 );

--- a/schema.sql
+++ b/schema.sql
@@ -27,7 +27,7 @@ CREATE TABLE `accessLog` (
     `requestUri` VARCHAR(255) NOT NULL,
     `requestMethod` INT(1) UNSIGNED NOT NULL,
     `requestParams` TEXT,
-    `responseTime` DATETIME NOT NULL,
+    `responseTime` DATETIME DEFAULT NULL,
     `responseStatus` INT(3) UNSIGNED NOT NULL,
     `response` TEXT,
     PRIMARY KEY (`accessLogID`),


### PR DESCRIPTION
Response fields need to allow NULL values, otherwise the writeBefore method will fail.