### PR TITLE
Only store 3-digit integer error codes

### DIFF
--- a/src/AccessLog.php
+++ b/src/AccessLog.php
@@ -224,6 +224,12 @@ class AccessLog {
             $customCols .= ', ' . $k;
         }
 
+        // Force storage of only 3-digit, numeric error codes
+        if ($resCode !== null) {
+            $resCode = is_numeric($resCode) ? (int) $resCode : 500;
+            $resCode = $resCode < 1000 ? $resCode : 500;
+        }
+
         $query = $this->db->prepare('
                 INSERT INTO ' . $this->settings['tableName'] . '
                     (requestTime, requestUri, requestMethod, requestParams, responseTime, responseStatus, response' . $customCols . ')
@@ -260,6 +266,12 @@ class AccessLog {
         }
         if (!empty($customCols)) {
             $customCols = ',' . $customCols;
+        }
+
+        // Force storage of only 3-digit, numeric error codes
+        if ($resCode !== null) {
+            $resCode = is_numeric($resCode) ? (int) $resCode : 500;
+            $resCode = $resCode < 1000 ? $resCode : 500;
         }
 
         $query = $this->db->prepare('


### PR DESCRIPTION
Forces the table constraint of integer response codes, and limits to < 1000.