### PR TITLE
PHP 8.0 Downgrade 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
 	"keywords": ["Slim Framework", "access log", "audit log", "accounting"],
 	"readme": "./README.md",
 	"require": {
-		"php": ">=8.1",
+		"php": ">=8.0",
 		"ext-json": "*",
 		"ext-pdo": "*",
         "slim/psr7": "^1.5",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
 		"php": ">=8.1",
 		"ext-json": "*",
 		"ext-pdo": "*",
-        "slim/psr7": "^1.5"
+        "slim/psr7": "^1.5",
+        "psr/http-server-handler": "^1.0"
 	},
 	"autoload": {
 		"psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -7,11 +7,10 @@
 	"keywords": ["Slim Framework", "access log", "audit log", "accounting"],
 	"readme": "./README.md",
 	"require": {
-		"php": ">=7.1",
+		"php": ">=8.1",
 		"ext-json": "*",
 		"ext-pdo": "*",
-		"psr/container": "*",
-		"psr/http-message": "*"
+        "slim/psr7": "^1.5"
 	},
 	"autoload": {
 		"psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 	},
 	"autoload": {
 		"psr-4": {
-			"jstnryan\\AccessLog\\": "src/"
+			"HealthAware\\AccessLog\\": "src/"
 		}
 	},
 	"authors": [

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
-    "name": "jstnryan/slim-access-log",
+    "name": "healthaware/slim-access-log",
     "description": "Access auditing middleware intended for use with Slim Framework applications",
-	"homepage":"https://github.com/jstnryan/slim-access-log",
+	"homepage":"https://github.com/healthaware/slim-access-log",
 	"license": "MIT",
 	"type": "library",
 	"keywords": ["Slim Framework", "access log", "audit log", "accounting"],

--- a/src/AccessLog.php
+++ b/src/AccessLog.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace jstnryan\AccessLog;
+namespace HealthAware\AccessLog;
 
 use DateTime;
 use Exception;


### PR DESCRIPTION
## What changed?
PHP 8.1 was replaced with a PHP 8.0 dependency

## Why are the changes needed?
We've decided to do the PHP 8 upgrade to .0 instead of 8.1 due to outstanding issues with PHP 8.1 in the Connect application.

## How can other developers test the changes?
Testing is ongoing through the deployment process.

## Relevant Links
- Jira ticket: https://medicomhealth.atlassian.net/browse/COL-272


- [ ] All Changes Tested - In progress
- [ ] All Ticket Requirements Met
- [x] Documentation Added/Updated
- [ ] Automated Tests Added/Updated
